### PR TITLE
fix get_single_post function to embed reactions

### DIFF
--- a/views/post_requests.py
+++ b/views/post_requests.py
@@ -138,7 +138,9 @@ def get_single_post(id):
             u.profile_image_url,
             u.created_on,
             u.active,
+            r.id reaction_id,
             r.emoji,
+            t.id tag_id,
             t.label tag_label
         FROM Posts p
         JOIN Categories c
@@ -192,10 +194,14 @@ def get_single_post(id):
             data["tag_id"],
             data["label"]
         )
-        
+        reaction = Reaction(
+            data["reaction_id"],
+            data["emoji"]
+            )
         post.user = user.__dict__
         post.category = category.__dict__
         post.tag = tag.__dict__
+        post.reaction = reaction.__dict__
 
 
         return json.dumps(post.__dict__)


### PR DESCRIPTION
# Ticket

Please provide a link to the ticket related to this change

# Description

- fixed logic inside of get_single_post function, so that reaction is embedded in the post.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules